### PR TITLE
feat: detecting devmode by DevSupport property and window flag #9

### DIFF
--- a/packages/ide-toolbox/src/config.ts
+++ b/packages/ide-toolbox/src/config.ts
@@ -1,1 +1,1 @@
-export const DEV_MODE = process.env.REACT_APP_IDE_DEVMODE === "true";
+export const DEV_MODE = (window as any).REACT_BUDDY_IDE_DEVMODE === true;

--- a/packages/ide-toolbox/src/index.ts
+++ b/packages/ide-toolbox/src/index.ts
@@ -1,5 +1,3 @@
-import "./routing/routing-api-init";
-
 export * from "./previews/dev-support";
 export * from "./previews/previews";
 export * from "./previews/component-preview";

--- a/packages/ide-toolbox/src/previews/dev-support.tsx
+++ b/packages/ide-toolbox/src/previews/dev-support.tsx
@@ -3,8 +3,9 @@ import { DEV_MODE } from "../config";
 
 export interface InitialHookStatus {
   loading: boolean,
-  error: boolean
+  error: boolean,
 }
+
 interface DevBootstrapProps {
   ComponentPreviews: React.FC
 }
@@ -12,7 +13,8 @@ interface DevBootstrapProps {
 interface DevSupportProps {
   children: JSX.Element,
   ComponentPreviews: React.FC,
-  useInitialHook?: () => InitialHookStatus
+  useInitialHook?: () => InitialHookStatus,
+  devmode?: boolean,
 }
 
 const withInitialHook: (
@@ -27,9 +29,11 @@ const withInitialHook: (
     }
 
     if(status.error) {
-      return <div>
-        Unable to bootstrap dev mode. Probably you need to run backend or enable backend mocking mode.
-      </div>;
+      return (
+        <div>
+          Unable to bootstrap dev mode. Probably you need to run backend or enable backend mocking mode.
+        </div>
+      )
     }
 
     return <DevBootstrap ComponentPreviews={ComponentPreviews}/>
@@ -45,12 +49,23 @@ const DevBootstrap: React.FC<DevBootstrapProps> = ({ComponentPreviews}) => {
     )
 };
 
-export const DevSupport: React.FC<DevSupportProps> = ({ children, ComponentPreviews, useInitialHook }) => {
-  if (DEV_MODE) {
+export const DevSupport: React.FC<DevSupportProps> = ({
+  children, 
+  ComponentPreviews, 
+  useInitialHook,
+  devmode
+}) => {
+  const isDevmode = enabledDevmode(devmode);
+
+  if(isDevmode) {
     return useInitialHook
-    ? withInitialHook(useInitialHook, ComponentPreviews)({})
-    : <DevBootstrap ComponentPreviews={ComponentPreviews}/>
+      ? withInitialHook(useInitialHook, ComponentPreviews)({})
+      : <DevBootstrap  ComponentPreviews={ComponentPreviews}/>
   }
 
   return <>{children}</>;
 };
+
+function enabledDevmode(devmode?: boolean) {
+  return devmode != null ? devmode : DEV_MODE;
+}

--- a/packages/ide-toolbox/src/previews/previews.tsx
+++ b/packages/ide-toolbox/src/previews/previews.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo, useEffect } from "react";
 import ToolsPanel from "./tools-panel";
 import { ToolsPropsModifier } from "./previews.types"
-import { DEV_MODE } from "../config";
-import { useRoute, PALETTE_PATH } from "../routing/routing";
+import { useRoute, PALETTE_PATH, historyPush } from "../routing/routing";
 import styles from "./previews.module.scss";
 
 interface Props {
@@ -28,14 +27,14 @@ export const Previews: React.FC<Props> = ({ children, palette = null }: Props) =
 
   useEffect(() => {
     (window as any).enableComponentsPropsPanelEditor = (toolsPanelStatus: boolean) => {
-      if (DEV_MODE){
         (window as any).setPropertiesEditPanelStatus
           ? (window as any).setPropertiesEditPanelStatus(toolsPanelStatus)
           : null;
 
         enableToolsPanel(toolsPanelStatus);
-      }
     }
+
+    (window as any).reactBuddyHistoryPush = historyPush;
   }, []);
 
   if(isPalettePath) {

--- a/packages/ide-toolbox/src/routing/routing-api-init.ts
+++ b/packages/ide-toolbox/src/routing/routing-api-init.ts
@@ -1,6 +1,0 @@
-import {DEV_MODE} from "../config";
-import {historyPush} from "./routing";
-
-if(DEV_MODE) {
-  (window as any).reactBuddyHistoryPush = historyPush;
-}


### PR DESCRIPTION
affects: @react-buddy/ide-toolbox

BREAKING CHANGE:
detecting devmode by DevSupport property and window.REACT_BUDDY_IDE_DEVMODE flag